### PR TITLE
Fix formatting of cice grid file

### DIFF
--- a/esmgrids/cice_grid.py
+++ b/esmgrids/cice_grid.py
@@ -1,5 +1,6 @@
 import numpy as np
 import netCDF4 as nc
+from warnings import warn
 
 from esmgrids.base_grid import BaseGrid
 
@@ -143,7 +144,10 @@ class CiceGrid(BaseGrid):
         if variant == "cice5-auscom":
             angleT = self._create_2d_nc_var(f, "angleT")
         else:  # variant==cice6
+            if variant != "cice6":
+                warn(f"{variant} not recognised, using variant='cice6'", UserWarning)
             angleT = self._create_2d_nc_var(f, "anglet")
+
         angleT.units = "radians"
         angleT.long_name = "Rotation angle of T cells."
         angleT.standard_name = "angle_of_rotation_from_east_to_x"

--- a/esmgrids/cice_grid.py
+++ b/esmgrids/cice_grid.py
@@ -1,6 +1,5 @@
 import numpy as np
 import netCDF4 as nc
-from warnings import warn
 
 from esmgrids.base_grid import BaseGrid
 
@@ -91,6 +90,8 @@ class CiceGrid(BaseGrid):
             The name of the mask file to write
         metadata: dict
             Any global or variable metadata attributes to add to the files being written
+        variant: str
+            Use variant='cice5-auscom' for access-om2/cice5-auscom builds, otherwise use None
         """
 
         if variant is not None and variant != "cice5-auscom":
@@ -100,10 +101,12 @@ class CiceGrid(BaseGrid):
         f = nc.Dataset(grid_filename, "w")
 
         # Create dimensions.
-        f.createDimension("ni", self.num_lon_points)
-        # ni is the grid_longitude but doesn't have a value other than its index
-        f.createDimension("nj", self.num_lat_points)
-        # nj is the grid_latitude but doesn't have a value other than its index
+        f.createDimension(
+            "ni", self.num_lon_points
+        )  # ni is the grid_longitude but doesn't have a value other than its index
+        f.createDimension(
+            "nj", self.num_lat_points
+        )  # nj is the grid_latitude but doesn't have a value other than its index
 
         # Make all CICE grid variables.
         # names are based on https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html

--- a/esmgrids/cice_grid.py
+++ b/esmgrids/cice_grid.py
@@ -79,7 +79,7 @@ class CiceGrid(BaseGrid):
             complevel=1,
         )
 
-    def write(self, grid_filename, mask_filename, metadata=None, variant="cice5-auscom"):
+    def write(self, grid_filename, mask_filename, metadata=None, variant=None):
         """
         Write out CICE grid to netcdf
 
@@ -92,6 +92,9 @@ class CiceGrid(BaseGrid):
         metadata: dict
             Any global or variable metadata attributes to add to the files being written
         """
+
+        if variant is not None and variant != "cice5-auscom":
+            raise NotImplementedError(f"{variant} not recognised")
 
         # Grid file
         f = nc.Dataset(grid_filename, "w")
@@ -143,9 +146,7 @@ class CiceGrid(BaseGrid):
 
         if variant == "cice5-auscom":
             angleT = self._create_2d_nc_var(f, "angleT")
-        else:  # variant==cice6
-            if variant != "cice6":
-                warn(f"{variant} not recognised, using variant='cice6'", UserWarning)
+        elif variant is None:
             angleT = self._create_2d_nc_var(f, "anglet")
 
         angleT.units = "radians"

--- a/esmgrids/cice_grid.py
+++ b/esmgrids/cice_grid.py
@@ -31,7 +31,11 @@ class CiceGrid(BaseGrid):
             area_t = f.variables["tarea"][:]
             area_u = f.variables["uarea"][:]
 
-            angle_t = np.rad2deg(f.variables["angleT"][:])
+            try:
+                angle_t = np.rad2deg(f.variables["anglet"][:])
+            except KeyError:
+                angle_t = np.rad2deg(f.variables["angleT"][:])
+
             angle_u = np.rad2deg(f.variables["angle"][:])
 
             if "clon_t" in f.variables:
@@ -69,12 +73,12 @@ class CiceGrid(BaseGrid):
         return f.createVariable(
             name,
             "f8",
-            dimensions=("ny", "nx"),
+            dimensions=("nj", "ni"),
             compression="zlib",
             complevel=1,
         )
 
-    def write(self, grid_filename, mask_filename, metadata=None):
+    def write(self, grid_filename, mask_filename, metadata=None, variant="cice5-auscom"):
         """
         Write out CICE grid to netcdf
 
@@ -92,10 +96,10 @@ class CiceGrid(BaseGrid):
         f = nc.Dataset(grid_filename, "w")
 
         # Create dimensions.
-        f.createDimension("nx", self.num_lon_points)
-        # nx is the grid_longitude but doesn't have a value other than its index
-        f.createDimension("ny", self.num_lat_points)
-        # ny is the grid_latitude but doesn't have a value other than its index
+        f.createDimension("ni", self.num_lon_points)
+        # ni is the grid_longitude but doesn't have a value other than its index
+        f.createDimension("nj", self.num_lat_points)
+        # nj is the grid_latitude but doesn't have a value other than its index
 
         # Make all CICE grid variables.
         # names are based on https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html
@@ -135,7 +139,11 @@ class CiceGrid(BaseGrid):
         angle.standard_name = "angle_of_rotation_from_east_to_x"
         angle.coordinates = "ulat ulon"
         angle.grid_mapping = "crs"
-        angleT = self._create_2d_nc_var(f, "angleT")
+
+        if variant == "cice5-auscom":
+            angleT = self._create_2d_nc_var(f, "angleT")
+        else:  # variant==cice6
+            angleT = self._create_2d_nc_var(f, "anglet")
         angleT.units = "radians"
         angleT.long_name = "Rotation angle of T cells."
         angleT.standard_name = "angle_of_rotation_from_east_to_x"
@@ -185,8 +193,8 @@ class CiceGrid(BaseGrid):
         # Mask file
         f = nc.Dataset(mask_filename, "w")
 
-        f.createDimension("nx", self.num_lon_points)
-        f.createDimension("ny", self.num_lat_points)
+        f.createDimension("ni", self.num_lon_points)
+        f.createDimension("nj", self.num_lat_points)
         mask = self._create_2d_nc_var(f, "kmt")
         mask.grid_mapping = "crs"
         mask.standard_name = "sea_binary_mask"

--- a/esmgrids/cli.py
+++ b/esmgrids/cli.py
@@ -15,7 +15,7 @@ def cice_from_mom():
     parser.add_argument("--ocean_mask", type=str, help="Input MOM ocean_mask.nc mask file")
     parser.add_argument("--cice_grid", type=str, default="grid.nc", help="Output CICE grid file")
     parser.add_argument("--cice_kmt", type=str, default="kmt.nc", help="Output CICE kmt file")
-    parser.add_argument("--cice_variant", type=str, default="cice5-auscom", help="cice variant")
+    parser.add_argument("--cice_variant", type=str, default=None, help="Cice variant")
 
     args = parser.parse_args()
     ocean_hgrid = os.path.abspath(args.ocean_hgrid)

--- a/esmgrids/cli.py
+++ b/esmgrids/cli.py
@@ -15,7 +15,9 @@ def cice_from_mom():
     parser.add_argument("--ocean_mask", type=str, help="Input MOM ocean_mask.nc mask file")
     parser.add_argument("--cice_grid", type=str, default="grid.nc", help="Output CICE grid file")
     parser.add_argument("--cice_kmt", type=str, default="kmt.nc", help="Output CICE kmt file")
-    parser.add_argument("--cice_variant", type=str, default=None, help="Cice variant")
+    parser.add_argument(
+        "--cice_variant", type=str, default=None, help="Cice variant, valid options = [None, 'cice5-auscom'] "
+    )
 
     args = parser.parse_args()
     ocean_hgrid = os.path.abspath(args.ocean_hgrid)

--- a/esmgrids/cli.py
+++ b/esmgrids/cli.py
@@ -15,18 +15,20 @@ def cice_from_mom():
     parser.add_argument("--ocean_mask", type=str, help="Input MOM ocean_mask.nc mask file")
     parser.add_argument("--cice_grid", type=str, default="grid.nc", help="Output CICE grid file")
     parser.add_argument("--cice_kmt", type=str, default="kmt.nc", help="Output CICE kmt file")
+    parser.add_argument("--cice_variant", type=str, default="cice5-auscom", help="cice variant")
 
     args = parser.parse_args()
     ocean_hgrid = os.path.abspath(args.ocean_hgrid)
     ocean_mask = os.path.abspath(args.ocean_mask)
     cice_grid = os.path.abspath(args.cice_grid)
     cice_kmt = os.path.abspath(args.cice_kmt)
+    cice_variant = args.cice_variant
 
     version = safe_version()
     runcmd = (
         f"Created using https://github.com/COSIMA/esmgrids {version}: "
         f"cice_from_mom --ocean_hgrid={ocean_hgrid} --ocean_mask={ocean_mask} "
-        f"--cice_grid={cice_grid} --cice_kmt={cice_kmt}"
+        f"--cice_grid={cice_grid} --cice_kmt={cice_kmt} --cice_variant={cice_variant}"
     )
     provenance_metadata = {
         "inputfile": (
@@ -37,4 +39,4 @@ def cice_from_mom():
 
     mom = MomGrid.fromfile(ocean_hgrid, mask_file=ocean_mask)
     cice = CiceGrid.fromgrid(mom)
-    cice.write(cice_grid, cice_kmt, metadata=provenance_metadata)
+    cice.write(cice_grid, cice_kmt, metadata=provenance_metadata, variant=cice_variant)

--- a/test/test_cice_grid.py
+++ b/test/test_cice_grid.py
@@ -175,7 +175,7 @@ def test_cice_kmt(mom_grid, grids):
 
 def test_cice_grid_attributes(grids):
     # Test: do the expected attributes to exist in the cice ds
-
+To-do: rewrite test using the CF-checker (or similar)
     cf_attributes = {
         "ulat": {"standard_name": "latitude", "units": "radians"},
         "ulon": {"standard_name": "longitude", "units": "radians"},

--- a/test/test_cice_grid.py
+++ b/test/test_cice_grid.py
@@ -1,6 +1,5 @@
 import pytest
 import xarray as xr
-import warnings
 from numpy.testing import assert_allclose
 from numpy import deg2rad
 from subprocess import run
@@ -14,6 +13,7 @@ from esmgrids.cice_grid import CiceGrid
 # going higher resolution than 0.1 has too much computational cost
 _test_resolutions = [4, 0.1]
 
+# run test using the valid cice variants
 _variants = ["cice5-auscom", None]
 
 
@@ -254,14 +254,17 @@ def test_variant(mom_grid, tmp_path):
     mom = MomGrid.fromfile(mom_grid.path, mask_file=mom_grid.mask_path)
     cice = CiceGrid.fromgrid(mom)
 
+    # invalid variant (="andrew")
     with pytest.raises(NotImplementedError, match="andrew not recognised"):
         cice.write(str(tmp_path) + "/grid2.nc", str(tmp_path) + "/kmt2.nc", variant="andrew")
 
+    # valid variant (="cice5-auscom")
     try:
         cice.write(str(tmp_path) + "/grid2.nc", str(tmp_path) + "/kmt2.nc", variant="cice5-auscom")
     except:
         assert False, "Failed to write cice grid with valid input arguments provided"
 
+    # valid variant (default = None)
     try:
         cice.write(str(tmp_path) + "/grid2.nc", str(tmp_path) + "/kmt2.nc")
     except:

--- a/test/test_cice_grid.py
+++ b/test/test_cice_grid.py
@@ -10,7 +10,7 @@ from pathlib import Path
 # create test grids at 4 degrees and 0.1 degrees
 # 4 degress is the lowest tested in ocean_model_grid_generator
 # going higher resolution than 0.1 has too much computational cost
-_test_resolutions = [4]  # , 0.1]
+_test_resolutions = [4, 0.1]
 
 _variants = ["cice5-auscom", "cice6", None]
 
@@ -175,7 +175,7 @@ def test_cice_kmt(mom_grid, grids):
 
 def test_cice_grid_attributes(grids):
     # Test: do the expected attributes to exist in the cice ds
-To-do: rewrite test using the CF-checker (or similar)
+    # To-do: rewrite test using the CF-checker (or similar)
     cf_attributes = {
         "ulat": {"standard_name": "latitude", "units": "radians"},
         "ulon": {"standard_name": "longitude", "units": "radians"},

--- a/test/test_grids.py
+++ b/test/test_grids.py
@@ -3,14 +3,11 @@ import sh
 import os
 import sys
 import numpy as np
-import netCDF4 as nc
 
 my_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(my_dir, "../"))
 
-from esmgrids.mom_grid import MomGrid  # noqa
 from esmgrids.core2_grid import Core2Grid  # noqa
-from esmgrids.cice_grid import CiceGrid  # noqa
 from esmgrids.util import calc_area_of_polygons  # noqa
 
 data_tarball = "test_data.tar.gz"


### PR DESCRIPTION
This PR fixes two issues:

- In CICE6, angle of t-cell is called `anglet` however in the cice5-auscom build, we called this `angleT`. 
- To make it easier to combine this file with cice history output, use names `ni`, `nj` for x and y dimensions. In conjunction with https://github.com/COSIMA/MOM6-CICE6/pull/54, this should allow a straight / no-warnings `xr.merge` of the grid with history output. Thanks to @aidanheerdegen for the suggestion.

Closes #16